### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
-  before_action :set_product, only: [:edit, :show]
+  before_action :set_product, only: [:show]
 
   def index
     @products = Product.order('created_at DESC')
@@ -17,19 +17,6 @@ class ProductsController < ApplicationController
     else
       render :new
     end
-  end
-
-  def destroy
-    product = Product.find(params[:id])
-    product.destroy
-  end
-
-  def edit
-  end
-
-  def update
-    product = Product.find(params[:id])
-    product.update(product_params)
   end
 
   def show

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
-  before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index, :show]
+  before_action :set_product, only: [:edit, :show]
 
   def index
     @products = Product.order('created_at DESC')
@@ -24,7 +25,6 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    @product = Product.find(params[:id])
   end
 
   def update
@@ -33,7 +33,6 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
   end
 
   private
@@ -44,5 +43,9 @@ class ProductsController < ApplicationController
 
   def product_params
     params.require(:product).permit(:name, :description, :price, :category_id, :condition_id, :delivery_fee_id, :prefecture_id, :shipping_time_id, :user, :content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_product
+    @product = Product.find(params[:id])
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,6 +18,24 @@ class ProductsController < ApplicationController
     end
   end
 
+  def destroy
+    product = Product.find(params[:id])
+    product.destroy
+  end
+
+  def edit
+    @product = Product.find(params[:id])
+  end
+
+  def update
+    product = Product.find(params[:id])
+    product.update(product_params)
+  end
+
+  def show
+    @product = Product.find(params[:id])
+  end
+
   private
 
   def move_to_index

--- a/app/javascript/tax.js
+++ b/app/javascript/tax.js
@@ -11,4 +11,7 @@ function tax_calc(){
     profit_field.innerHTML = profit;
   });
 }
-window.addEventListener("load", tax_calc);
+
+if(document.URL.match('/products/new', '/products/.*/edit')){
+  window.addEventListener("load", tax_calc);
+}

--- a/app/javascript/tax.js
+++ b/app/javascript/tax.js
@@ -1,13 +1,13 @@
 function tax_calc(){
   let price_element = document.getElementById("item-price");
   price_element.addEventListener('input', () => {
-    //price = parseInt(price, 10)
     let price = document.getElementById("item-price").value;
-    let tax_price = parseInt((price / 10), 10);
-    let profit = parseInt(price - tax_price, 10);
+    let tax_price = price / 10;
+    let tax_price_int = parseInt(tax_price, 10);
+    let profit = parseInt(price - tax_price_int, 10);
     const tax_price_field = document.getElementById("add-tax-price");
     const profit_field = document.getElementById("profit");
-    tax_price_field.innerHTML = tax_price;
+    tax_price_field.innerHTML = tax_price_int;
     profit_field.innerHTML = profit;
   });
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <%= render "shared/second-header"%>
 
 <%# 「モデル名」にはUserモデルであれば@userを渡しましょう。「新規登録機能へのパス」は、devise導入後にrails routesを実行してdevise/registrations#createへのパスを確認し、記載してください。 %>
-<%= form_with model: @user, url:  user_registration_path, class: 'registration-main', local: true do |f| %>
+<%= form_with model: @user, url: user_registration_path, class: 'registration-main', local: true do |f| %>
 <%# //「モデル名」にはUserモデルであれば@userを渡しましょう。「新規登録機能へのパス」は、devise導入後にrails routesを実行してdevise/registrations#createへのパスを確認し、記載してください。 %>
 <div class='form-wrap'>
   <div class='form-header'>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/second-header"%>
 
-<%= form_with class: 'registration-main', local: true do |f| %>
+<%= form_with model: @user, url: user_session_path, class: 'registration-main', local: true do |f| %>
 <div class='form-wrap'>
   <div class='form-header'>
     <h1 class='form-header-text'>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @product, url: product_path, method: :patch, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @products.each do |product| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to product_path(product.id), method: :get do %>
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" if product.image.attached? %>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -55,7 +55,7 @@
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-condition"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-delivery-fee"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_time_id, ShippingTime.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:shipping_time_id, ShippingTime.all, :id, :name, {}, {class:"select-box", id:"item-shipping-time"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -7,9 +7,9 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @product, url: products_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# エラー発生時のメッセージ表示部分 %>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# /エラー発生時のメッセージ表示部分 %>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -98,7 +98,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -8,11 +8,9 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @product.image ,class:"item-box-img" if @product.image.attached? %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -22,25 +20,17 @@
         (税込) 送料込み
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in?%>
       <% if current_user.id == @product.user_id %>
       <%= link_to '商品の編集', edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', product_path(@product.id), method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
       <% else %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <% end %>
     <% else %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @product.description %></span>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @product.price %>円
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -25,9 +25,9 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', product_path(@product.id), method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
@@ -37,17 +37,17 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category_id %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -7,7 +7,7 @@
       <%= @product.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image ,class:"item-box-img" if @product.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -24,13 +24,19 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', product_path(@product.id), method: :delete, class:'item-destroy' %>
+    <% if user_signed_in?%>
+      <% if current_user.id == @product.user_id %>
+      <%= link_to '商品の編集', edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', product_path(@product.id), method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <% else %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% else %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
@@ -43,27 +49,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @product.user %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @product.category_id %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.shipping_time.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
     <ul class='lists-right'>
       <%# deviseを導入できたら、ログインの有無で表示が変わるように分岐しましょう%>
       <% if user_signed_in? %>
-        <li><%= link_to current_user.nickname, user_registration_path, class: "user-nickname" %></li>
+        <li><%= link_to current_user.nickname, user_registration_path(current_user.id), class: "user-nickname" %></li>
         <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "logout" %></li>
       <% else %>
         <li><%= link_to 'ログイン', new_user_session_path, class: "login" %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,4 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
   resources :products
-  resources :users, only: :show
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
   resources :products
+  resources :users, only: :show
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
-  resources :products, only: [:index, :new, :create]
+  resources :products
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :product do
     name              { 'あア亜Ａ１！' }
     description       { '商品説明\nｼｮｳﾋﾝｾﾂﾒｲ\ndescription' }
-    category_id       { 2}
+    category_id       {2}
     condition_id      {2}
     delivery_fee_id   {2}
     prefecture_id     {2}
@@ -13,6 +13,6 @@ FactoryBot.define do
       item.image.attach(io: File.open('public/images/test_image.jpg'), filename: 'test_image.jpg', content_type: 'image/jpg')
     end
 
-    user
+    association :user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     nickname    { 'あア亜Ａ１！' }
-    email       { Faker::Internet.free_email }
+    email       { 'test@test.com' }
     password    { 'abc123' }
     password_confirmation { password }
     first_name            {'あア亜'}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -64,4 +64,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include SignInSupport
 end

--- a/spec/requests/products_request_spec.rb
+++ b/spec/requests/products_request_spec.rb
@@ -1,4 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe 'Products', type: :request do
+  before do
+    @product = FactoryBot.create(:product)
+  end
+
+  describe 'GET #index' do
+    it 'indexアクションにリクエストすると正常にレスポンスが返ってくる' do
+      get root_path
+      expect(response.status).to eq 200
+    end
+    it 'indexアクションにリクエストするとレスポンスに出品済み商品の名前が存在する' do
+      get root_path
+      expect(response.body).to include @product.name
+    end
+    it 'indexアクションにリクエストするとレスポンスに出品済み商品の画像URLが存在する' do
+      get root_path
+      expect(response.body).to include @product.image
+    end
+    it 'indexアクションにリクエストするとレスポンスに「出品する」ボタンが存在する' do
+      get root_path
+      expect(response.body).to include '出品する'
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,26 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe 'Tweets', type: :request do
-  before do
-    @user = FactoryBot.create(:user)
-  end
-
-  describe 'GET /tweets' do
-    it 'indexアクションにリクエストすると正常にレスポンスが返ってくる' do
-      get root_path
-      expect(response.status).to eq 200
-    end
-    it 'indexアクションにリクエストするとレスポンスに出品済みの商品のテキストが存在する' do
-      get root_path
-      expect(response.body).to include @user.text
-    end
-    it 'indexアクションにリクエストするとレスポンスに出品済みの商品の画像URLが存在する' do
-      get root_path
-      expect(response.body).to include @user.image
-    end
-    it 'indexアクションにリクエストするとレスポンスに「出品する」ボタンが存在する' do
-      get root_path
-      expect(response.body).to include '出品する'
-    end
-  end
 end

--- a/spec/support/sign_in_support.rb
+++ b/spec/support/sign_in_support.rb
@@ -1,0 +1,9 @@
+module SignInSupport
+  def sign_in(user)
+    visit root_path
+    click_on('ログイン')
+    fill_in 'email', with: user.email 
+    fill_in 'password', with: user.password
+    click_on('ログイン')
+  end
+end

--- a/spec/system/products_spec.rb
+++ b/spec/system/products_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe "Products", type: :system do
+  describe '商品出品機能' do
+    before do
+      @product = FactoryBot.create(:product)
+    end
+
+    context 'ユーザーログイン状態且つ出品成功時' do
+      it '' do
+        # トップページに移動してからログイン状態にする
+        sign_in(@product.user)
+        # トップページに「出品する」ボタンが存在する
+        expect(page).to have_content('出品する')
+        # トップページに「出品する」ボタン及び「新規投稿商品」リンクが存在する
+        expect(page).to have_content('新規投稿商品')
+        # 商品出品ページへ移動する
+        click_on('新規投稿商品')
+        # 商品情報を入力する
+        image_path = Rails.root.join('public/images/test_image.jpg')
+        attach_file('item-image', image_path)
+        fill_in 'item-name', with: @product.name
+        fill_in 'item-info', with: @product.description
+        select @product.category.name, from: 'item-category'
+        select @product.condition.name, from: 'item-condition'
+        select @product.delivery_fee.name, from: 'item-delivery-fee'
+        select @product.prefecture.name, from: 'item-prefecture'
+        select @product.shipping_time.name, from: 'item-shipping-time'
+        fill_in 'item-price', with: @product.price
+        # 「出品する」ボタンを押すと、productモデルのカウントが1上がることを確認する
+        expect{
+          find('input[name="commit"]').click
+        }.to change { Product.count }.by(1)
+        # トップページへ遷移する
+        expect(current_path).to eq products_path
+        # トップページに先ほど出品した商品の名前が表示されることを確認する
+        expect(page).to have_content(@product.name)
+        # トップページに先ほど出品した商品の画像が表示されることを確認する
+        expect(page).to have_selector(".item-img")
+      end
+    end
+
+    context 'ユーザーログイン状態且つ出品失敗時' do
+      # トップページに移動する
+      # トップページに「出品する」ボタン及び「新規投稿商品」リンクが存在する
+      # 商品出品ページへ移動する
+      # 商品情報を入力しない
+      # 「出品する」ボタンを押すと、productモデルのカウントが1上がらないことを確認する
+      # 商品出品ページから遷移していないことを確認する
+    end
+
+    context 'ユーザーログイン状態で「もどる」ボタン押下時' do
+      # トップページに移動する
+      # トップページに「出品する」ボタン及び「新規投稿商品」リンクが存在する
+      # 商品出品ページへ移動する
+      # 「もどる」ボタンを押すとトップページに遷移することを確認する
+    end
+
+    context 'ユーザー未ログイン状態' do
+      # トップページに移動する
+      # トップページに「出品する」ボタン及び「新規投稿商品」リンクが存在する
+      # 商品出品ページへ移動しようとすると、新規会員登録画面に遷移することを確認する
+    end
+  end
+  
+  describe '' do
+  end
+
+end


### PR DESCRIPTION
## 商品詳細表示機能の実装
### 商品詳細表示機能として、下記を実装しました。

1. productsコントローラーにshowアクションを実装
1. viewのshow.html.erbに該当の商品情報及び画像を表示する記述を実装
    - 商品情報編集・削除のボタンと商品購入のボタンのどちらを表示するか、出品者か否かで判別する式を記述
1. ルーティングの７つのアクションを統合

*商品詳細ページスクリーンショット*
[出品者の時](https://gyazo.com/7094bd8d6eb9b2c627dd9f8fc9e2f71f "商品詳細画面")
[出品者以外または非ログイン時](https://gyazo.com/27aa2f54945fb95c3b4ab17dbd913e5e "商品詳細画面")

ご精査の程をよろしくお願いいたします。